### PR TITLE
Added support for launching custom boards and end-to-end tests in Bej…

### DIFF
--- a/src/main/java/nl/tudelft/bejeweled/CustomBoardLauncher.java
+++ b/src/main/java/nl/tudelft/bejeweled/CustomBoardLauncher.java
@@ -28,6 +28,11 @@ public class CustomBoardLauncher extends Launcher {
         return boardLocation;
     }
 
+    /**
+     * Creates the board the game wil use from file.
+     * @param sceneNodes The group containing the jewel nodes.
+     * @return The board.
+     */
     @Override
     public Board makeBoard(Group sceneNodes) {
         return getBoardFactory().fromTextGenerateBoard(boardLocation, sceneNodes);

--- a/src/main/java/nl/tudelft/bejeweled/CustomBoardLauncher.java
+++ b/src/main/java/nl/tudelft/bejeweled/CustomBoardLauncher.java
@@ -10,6 +10,9 @@ import nl.tudelft.bejeweled.board.Board;
  */
 public class CustomBoardLauncher extends Launcher {
 
+    /**
+     * The location of the board.
+     */
     private String boardLocation = "/board.txt";
 
     /**
@@ -21,8 +24,8 @@ public class CustomBoardLauncher extends Launcher {
     }
 
     /**
-     * Gets the location of the map file for the level.
-     * @return The map location.
+     * Gets the location of the board file for the board.
+     * @return The board location.
      */
     public String getLocation() {
         return boardLocation;
@@ -35,6 +38,7 @@ public class CustomBoardLauncher extends Launcher {
      */
     @Override
     public Board makeBoard(Group sceneNodes) {
-        return getBoardFactory().fromTextGenerateBoard(boardLocation, sceneNodes);
+        return getBoardFactory().fromTextGenerateBoard(boardLocation,
+                sceneNodes);
     }
 }

--- a/src/main/java/nl/tudelft/bejeweled/CustomBoardLauncher.java
+++ b/src/main/java/nl/tudelft/bejeweled/CustomBoardLauncher.java
@@ -1,0 +1,35 @@
+package nl.tudelft.bejeweled;
+
+import javafx.scene.Group;
+import nl.tudelft.bejeweled.board.Board;
+
+/**
+ * Created by Jeroen on 12-9-2015.
+ * Extension of the launcher class to load custom boards from text.
+ * Primarily used for testing purposes.
+ */
+public class CustomBoardLauncher extends Launcher {
+
+    private String boardLocation = "/board.txt";
+
+    /**
+     * Function to set the location of a custom board.
+     * @param newLocation the location of the board template file.
+     */
+    public void setLocation(String newLocation) {
+        boardLocation = newLocation;
+    }
+
+    /**
+     * Gets the location of the map file for the level.
+     * @return The map location.
+     */
+    public String getLocation() {
+        return boardLocation;
+    }
+
+    @Override
+    public Board makeBoard(Group sceneNodes) {
+        return getBoardFactory().fromTextGenerateBoard(boardLocation, sceneNodes);
+    }
+}

--- a/src/main/java/nl/tudelft/bejeweled/Launcher.java
+++ b/src/main/java/nl/tudelft/bejeweled/Launcher.java
@@ -1,9 +1,14 @@
 package nl.tudelft.bejeweled;
 
 import javafx.application.Application;
+import javafx.scene.Group;
 import javafx.stage.Stage;
+import nl.tudelft.bejeweled.board.Board;
+import nl.tudelft.bejeweled.board.BoardFactory;
 import nl.tudelft.bejeweled.game.BejeweledGame;
+import nl.tudelft.bejeweled.game.Game;
 import nl.tudelft.bejeweled.gui.BejeweledGui;
+import nl.tudelft.bejeweled.sprite.SpriteStore;
 
 /**
  * Created by Jeroen on 1-9-2015.
@@ -12,6 +17,10 @@ import nl.tudelft.bejeweled.gui.BejeweledGui;
 public class Launcher extends Application {
 
 	private static final int FPS_LIMIT = 60;
+
+    private SpriteStore spriteStore;
+
+    private BoardFactory boardFactory;
 	
     /**
      *  The current game.
@@ -41,23 +50,38 @@ public class Launcher extends Application {
      * @param theStage The primary stage to draw the GUI on
      */
     public void launchGame(Stage theStage) {
-        game = new BejeweledGame(FPS_LIMIT, "Bejeweled");
+        spriteStore = new SpriteStore();
+        game = new BejeweledGame(FPS_LIMIT, "Bejeweled", spriteStore);
+
+        boardFactory = getBoardFactory();
+        Group sceneNodes = new Group();
+        Board board = makeBoard(sceneNodes);
+        game.setSceneNodes(sceneNodes);
 
         // initialise the gui and map start/stop buttons
         bejeweledGui = new BejeweledGui(game, theStage);
 
         // initialise the game
-        game.initialise(bejeweledGui.getBoardPane(), bejeweledGui.getScoreLabel());
+        game.initialise(board, bejeweledGui.getBoardPane(), bejeweledGui.getScoreLabel());
 
         // begin game loop
         game.beginGameLoop();
     }
 
+    public Board makeBoard(Group sceneNodes) {
+        return boardFactory.generateBoard(sceneNodes);
+    }
+
     /**
-     * Getter method for the game.
-     * @return The game.
+     * @return A new board factory using the sprite store from
      */
-    public BejeweledGame getGame() {
-        return game;
+    protected BoardFactory getBoardFactory() {
+        return new BoardFactory(getSpriteStore());
+    }
+
+    public BejeweledGame getGame() { return game; }
+
+    protected SpriteStore getSpriteStore() {
+        return spriteStore;
     }
 }

--- a/src/main/java/nl/tudelft/bejeweled/board/Board.java
+++ b/src/main/java/nl/tudelft/bejeweled/board/Board.java
@@ -764,6 +764,9 @@ public class Board {
 		return selectionCursor;
 	}
 
+    /**
+     * Function to reset the entire grid[][] to null.
+     */
     public void resetGrid() {
         for (int x = 0; x < grid.length; x++) {
             for (int y = 0; y < grid[x].length; y++) {

--- a/src/main/java/nl/tudelft/bejeweled/board/Board.java
+++ b/src/main/java/nl/tudelft/bejeweled/board/Board.java
@@ -145,8 +145,8 @@ public class Board {
     
 	/**
      * Set up two jewels to be swapped, intended to undo an invalid move.
-     * @param j1 The first Jewel.
-     * @param j2 The second Jewel.
+     * @param jewel1 The first Jewel.
+     * @param jewel2 The second Jewel.
      */
     private void setToReverse(Jewel jewel1, Jewel jewel2) {
 		toReverseMove = true;
@@ -699,6 +699,15 @@ public class Board {
             }
     	}
     }
+
+    public void fillNullSpots() {
+        for (int x = 0; x < grid.length; x++) {
+            for (int y = 0; y < grid[x].length; y++) {
+                if(grid[x][y] == null)
+                    addRandomJewel(x, y);
+            }
+        }
+    }
     
     /**
 	 * Getter function for the current spriteStore.
@@ -754,4 +763,13 @@ public class Board {
 	public SelectionCursor getSelectionCursor() {
 		return selectionCursor;
 	}
+
+    public void resetGrid() {
+        for (int x = 0; x < grid.length; x++) {
+            for (int y = 0; y < grid[x].length; y++) {
+                grid[x][y].implode(sceneNodes);
+                grid[x][y] = null;
+            }
+        }
+    }
 }

--- a/src/main/java/nl/tudelft/bejeweled/board/Board.java
+++ b/src/main/java/nl/tudelft/bejeweled/board/Board.java
@@ -700,11 +700,16 @@ public class Board {
     	}
     }
 
+    /**
+     * This function fille the null spots in the grid[][] with Jewels
+     * at the start of the game.
+     */
     public void fillNullSpots() {
         for (int x = 0; x < grid.length; x++) {
             for (int y = 0; y < grid[x].length; y++) {
-                if(grid[x][y] == null)
+                if (grid[x][y] == null) {
                     addRandomJewel(x, y);
+                }
             }
         }
     }

--- a/src/main/java/nl/tudelft/bejeweled/board/BoardFactory.java
+++ b/src/main/java/nl/tudelft/bejeweled/board/BoardFactory.java
@@ -59,7 +59,7 @@ public class BoardFactory {
                 String[] parts = line.split("|");  
                 for (int j = 0; j < gridHeight; j++) {
                     int amr = Integer.parseInt(parts[j]);
-                    System.out.println(amr);
+                //    System.out.println(amr);
                     Jewel jewel = new Jewel(amr, k, j);
                     jewel.setxPos(k * spriteWidth);
                     jewel.setyPos(j * spriteHeight);

--- a/src/main/java/nl/tudelft/bejeweled/game/BejeweledGame.java
+++ b/src/main/java/nl/tudelft/bejeweled/game/BejeweledGame.java
@@ -188,4 +188,20 @@ public class BejeweledGame extends Game implements BoardObserver {
     public boolean isInProgress() {
         return inProgress;
     }
+
+    /**
+     * Getter method for the board.
+     * @return The board
+     */
+    public Board getBoard() {
+        return board;
+    }
+
+    /**
+     * Getter method for the score.
+     * @return The current score
+     */
+    public int getScore() {
+        return score;
+    }
 }

--- a/src/main/java/nl/tudelft/bejeweled/game/BejeweledGame.java
+++ b/src/main/java/nl/tudelft/bejeweled/game/BejeweledGame.java
@@ -13,7 +13,10 @@ import javafx.util.Duration;
 import nl.tudelft.bejeweled.board.Board;
 import nl.tudelft.bejeweled.board.BoardFactory;
 import nl.tudelft.bejeweled.board.BoardObserver;
+import nl.tudelft.bejeweled.sprite.Jewel;
 import nl.tudelft.bejeweled.sprite.SpriteStore;
+
+import java.util.Iterator;
 
 
 /**
@@ -25,7 +28,6 @@ public class BejeweledGame extends Game implements BoardObserver {
 	public static final int GRID_HEIGHT = 8;
 	public static final int SPRITE_WIDTH = 64;
 	public static final int SPRITE_HEIGHT = 64;
-
 
     /** The board class that maintains the jewels. */
     private Board board;
@@ -49,9 +51,9 @@ public class BejeweledGame extends Game implements BoardObserver {
     * @param framesPerSecond - The number of frames per second the game will attempt to render.
     * @param windowTitle - The title displayed in the window.
     */
-    public BejeweledGame(int framesPerSecond, String windowTitle) {
+    public BejeweledGame(int framesPerSecond, String windowTitle, SpriteStore spriteStore) {
         super(framesPerSecond, windowTitle);
-        spriteStore = new SpriteStore();
+        this.spriteStore = spriteStore;
         boardFactory = new BoardFactory(spriteStore);
     }
 
@@ -69,18 +71,14 @@ public class BejeweledGame extends Game implements BoardObserver {
 
         score = 0;
 
+        // fill board if game was stopped and started again
+        board.fillNullSpots();
+
         // Create the group that holds all the jewel nodes and create a game scene
-        setSceneNodes(new Group());
         gamePane.getChildren().add(new Scene(getSceneNodes(),
                 gamePane.getWidth(),
                 gamePane.getHeight()).getRoot());
 
-        // generate the jewels
-        board = boardFactory.generateBoard(getSceneNodes());
-
-        // start observing the board for callback events
-        board.addObserver(this);
-        
         // check for any combo's on the freshly created board
         int comboCount = board.checkBoardCombos();
         System.out.println("Combo Jewels on board: " + comboCount);
@@ -98,8 +96,10 @@ public class BejeweledGame extends Game implements BoardObserver {
         System.out.println("Game stopped");
 
         // remove the JavaFX group with jewel nodes
+    //    getSceneNodes().getChildren().removeAll();
         gamePane.getChildren().remove(getSceneNodes());
         spriteStore.removeAllSprites();
+        board.resetGrid();
 
         inProgress = false;
     }
@@ -109,15 +109,19 @@ public class BejeweledGame extends Game implements BoardObserver {
      * @param gamePane The primary scene.
      */
     @Override
-    public void initialise(Pane gamePane, Label scoreLabel) {
+    public void initialise(Board board, Pane gamePane, Label scoreLabel) {
         this.gamePane = gamePane;
         this.scoreLabel = scoreLabel;
+        this.board = board;
 
         // set initial score
         scoreLabel.setText(Integer.toString(score));
 
         // draw and stretch the board background
         gamePane.setStyle("-fx-background-image: url('/board.png'); -fx-background-size: cover;");
+
+        // start observing the board for callback events
+        board.addObserver(this);
 
         // set callback for clicking on the board
         gamePane.addEventFilter(MouseEvent.MOUSE_CLICKED,

--- a/src/main/java/nl/tudelft/bejeweled/game/Game.java
+++ b/src/main/java/nl/tudelft/bejeweled/game/Game.java
@@ -88,6 +88,7 @@ public abstract class Game {
 
     /**
      * Initialise the game world by update the JavaFX Stage.
+     * @param board The board of the game.
      * @param gamePane The primary scene.
      * @param scoreLabel The label for the score.
      */

--- a/src/main/java/nl/tudelft/bejeweled/game/Game.java
+++ b/src/main/java/nl/tudelft/bejeweled/game/Game.java
@@ -9,6 +9,7 @@ import javafx.scene.Group;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
 import javafx.util.Duration;
+import nl.tudelft.bejeweled.board.Board;
 import nl.tudelft.bejeweled.sprite.Sprite;
 import nl.tudelft.bejeweled.sprite.SpriteStore;
 
@@ -90,7 +91,7 @@ public abstract class Game {
      * @param gamePane The primary scene.
      * @param scoreLabel The label for the score.
      */
-    public abstract void initialise(Pane gamePane, Label scoreLabel);
+    public abstract void initialise(Board board, Pane gamePane, Label scoreLabel);
 
     /**Kicks off (plays) the Timeline objects containing one key frame
      * that simply runs indefinitely with each frame invoking a method
@@ -189,7 +190,7 @@ public abstract class Game {
      * @param sceneNodes The root container having many children nodes
      * to be displayed into the Scene area.
      */
-    protected void setSceneNodes(Group sceneNodes) {
+    public void setSceneNodes(Group sceneNodes) {
         this.sceneNodes = sceneNodes;
     }
 

--- a/src/test/java/nl/tudelft/bejeweled/game/BejeweledGameTest.java
+++ b/src/test/java/nl/tudelft/bejeweled/game/BejeweledGameTest.java
@@ -1,0 +1,52 @@
+package nl.tudelft.bejeweled.game;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javafx.application.Platform;
+import javafx.scene.control.Button;
+import javafx.stage.Stage;
+import nl.tudelft.bejeweled.CustomBoardLauncher;
+import nl.tudelft.bejeweled.Launcher;
+import nl.tudelft.bejeweled.game.BejeweledGame;
+import org.junit.After;
+import org.junit.Test;
+import org.testfx.framework.junit.ApplicationTest;
+
+/**
+ * Created by Jeroen on 12-9-2015.
+ */
+public class BejeweledGameTest extends ApplicationTest {
+
+    private CustomBoardLauncher launcher = new CustomBoardLauncher();
+    private Stage stage;
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        launcher.launchGame(primaryStage);
+    }
+
+    /**
+     * Quit the user interface when we're done.
+     */
+    @After
+    public void tearDown() { }
+
+    /**
+     * First test.
+     */
+    @Test
+    public void testStartGame() {
+        BejeweledGame game = launcher.getGame();
+        assertFalse(game.isInProgress());
+
+        clickOn("#buttonStart");
+
+        // start and stop the game concurrently with JavaFX thread
+        Platform.runLater(new Runnable() {
+            public void run() {
+                assertTrue(game.isInProgress());
+            }
+        });
+    }
+}

--- a/src/test/java/nl/tudelft/bejeweled/game/BejeweledGameTest.java
+++ b/src/test/java/nl/tudelft/bejeweled/game/BejeweledGameTest.java
@@ -4,17 +4,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import javafx.application.Platform;
-import javafx.scene.control.Button;
 import javafx.stage.Stage;
 import nl.tudelft.bejeweled.CustomBoardLauncher;
-import nl.tudelft.bejeweled.Launcher;
-import nl.tudelft.bejeweled.game.BejeweledGame;
 import org.junit.After;
 import org.junit.Test;
 import org.testfx.framework.junit.ApplicationTest;
 
 /**
  * Created by Jeroen on 12-9-2015.
+ * Test class for end to end testing the game.
  */
 public class BejeweledGameTest extends ApplicationTest {
 

--- a/src/test/java/nl/tudelft/bejeweled/game/BejeweledGameTest.java
+++ b/src/test/java/nl/tudelft/bejeweled/game/BejeweledGameTest.java
@@ -33,10 +33,11 @@ public class BejeweledGameTest extends ApplicationTest {
     public void tearDown() { }
 
     /**
-     * First test.
+     * Test of a user story where the user starts the game,
+     * swaps 2 jewels and then ends the game.
      */
     @Test
-    public void testStartGame() {
+    public void testMoveJewelNoWin() {
         BejeweledGame game = launcher.getGame();
         assertFalse(game.isInProgress());
 
@@ -46,6 +47,28 @@ public class BejeweledGameTest extends ApplicationTest {
         Platform.runLater(new Runnable() {
             public void run() {
                 assertTrue(game.isInProgress());
+            }
+        });
+
+        // click on 2 jewels that can be swapped
+        clickOn(game.getBoard().getGrid()[0][0].getNode());
+        clickOn(game.getBoard().getGrid()[0][1].getNode());
+
+        // verify the score is still the same.
+        Platform.runLater(new Runnable() {
+            public void run() {
+                assertTrue(game.getScore() == 0);
+            }
+        });
+
+        // stop the game
+        clickOn("#buttonStop");
+
+        // assert game is stopped
+        // start and stop the game concurrently with JavaFX thread
+        Platform.runLater(new Runnable() {
+            public void run() {
+                assertFalse(game.isInProgress());
             }
         });
     }


### PR DESCRIPTION
I had to change the way the board class is used, now the board is created one time (by the launcher) and after a game stops jewels are removed and when a new game starts jewels are added again.

This way you can use the CustomBoardLauncher in end-to-end test. i.e. create tests like the BejeweledGameTest where you can actually make the test click on start game and on specific jewels (and with the custom boards we can verify what should happen).